### PR TITLE
Fix a wrong key name

### DIFF
--- a/src/main/resources/algorithms/eod_public/2.0/schemas/plasma_cell_myeloma.json
+++ b/src/main/resources/algorithms/eod_public/2.0/schemas/plasma_cell_myeloma.json
@@ -185,14 +185,19 @@
     "used_for_staging" : false,
     "metadata" : [ "COC_REQUIRED", "SSDI", "CCCR_REQUIRED", "SEER_REQUIRED" ]
   }, {
-    "key" : "ldh_pretx_level",
-    "name" : "LDH (Lactate Dehydrogenase) Pretreatment Level",
-    "naaccr_item" : 3869,
-    "naaccr_xml_id" : "ldhPretreatmentLevel",
-    "default" : "9",
-    "table" : "ldh_pretreatment_level_82697",
-    "used_for_staging" : false,
-    "metadata" : [ "COC_REQUIRED", "SSDI", "CCCR_REQUIRED", "SEER_REQUIRED" ]
+    "key": "ldh_level",
+    "name": "LDH (Lactate Dehydrogenase) Pretreatment Level",
+    "naaccr_item": 3869,
+    "naaccr_xml_id": "ldhPretreatmentLevel",
+    "default": "9",
+    "table": "ldh_pretreatment_level_82697",
+    "used_for_staging": false,
+    "metadata": [
+      "COC_REQUIRED",
+      "SSDI",
+      "CCCR_REQUIRED",
+      "SEER_REQUIRED"
+    ]
   } ],
   "outputs" : [ {
     "key" : "naaccr_schema_id",

--- a/src/main/resources/algorithms/eod_public/2.0/schemas/plasma_cell_myeloma.json
+++ b/src/main/resources/algorithms/eod_public/2.0/schemas/plasma_cell_myeloma.json
@@ -185,19 +185,14 @@
     "used_for_staging" : false,
     "metadata" : [ "COC_REQUIRED", "SSDI", "CCCR_REQUIRED", "SEER_REQUIRED" ]
   }, {
-    "key": "ldh_level",
-    "name": "LDH (Lactate Dehydrogenase) Pretreatment Level",
-    "naaccr_item": 3869,
-    "naaccr_xml_id": "ldhPretreatmentLevel",
-    "default": "9",
-    "table": "ldh_pretreatment_level_82697",
-    "used_for_staging": false,
-    "metadata": [
-      "COC_REQUIRED",
-      "SSDI",
-      "CCCR_REQUIRED",
-      "SEER_REQUIRED"
-    ]
+    "key" : "ldh_level",
+    "name" : "LDH (Lactate Dehydrogenase) Pretreatment Level",
+    "naaccr_item" : 3869,
+    "naaccr_xml_id" : "ldhPretreatmentLevel",
+    "default" : "9",
+    "table" : "ldh_pretreatment_level_82697",
+    "used_for_staging" : false,
+    "metadata" : [ "COC_REQUIRED", "SSDI", "CCCR_REQUIRED", "SEER_REQUIRED" ]
   } ],
   "outputs" : [ {
     "key" : "naaccr_schema_id",

--- a/src/main/resources/algorithms/eod_public/2.0/tables/ldh_pretreatment_level_82697.json
+++ b/src/main/resources/algorithms/eod_public/2.0/tables/ldh_pretreatment_level_82697.json
@@ -7,9 +7,9 @@
   "notes" : "**Note 1:** Use the reference ranges from your lab to determine if LDH is normal.\n\n**Note 2:** Record this data item based on a blood test performed at diagnosis. In the absence of the lab test, a physician's statement of the exact value or interpretation can be used. Use the highest value available.\n\n**Note 3:** If there is no mention of the LDH, code 9.\n\n**Note 4:** If Schema Discriminator 1: Plasma Cell Myeloma Terminology is coded to 1 or 9, leave this SSDI blank.",
   "last_modified" : "2020-05-27T18:22:17.926Z",
   "definition" : [ {
-    "key": "ldh_level",
-    "name": "Code",
-    "type": "INPUT"
+    "key" : "ldh_level",
+    "name" : "Code",
+    "type" : "INPUT"
   }, {
     "key" : "description",
     "name" : "Description",

--- a/src/main/resources/algorithms/eod_public/2.0/tables/ldh_pretreatment_level_82697.json
+++ b/src/main/resources/algorithms/eod_public/2.0/tables/ldh_pretreatment_level_82697.json
@@ -7,9 +7,9 @@
   "notes" : "**Note 1:** Use the reference ranges from your lab to determine if LDH is normal.\n\n**Note 2:** Record this data item based on a blood test performed at diagnosis. In the absence of the lab test, a physician's statement of the exact value or interpretation can be used. Use the highest value available.\n\n**Note 3:** If there is no mention of the LDH, code 9.\n\n**Note 4:** If Schema Discriminator 1: Plasma Cell Myeloma Terminology is coded to 1 or 9, leave this SSDI blank.",
   "last_modified" : "2020-05-27T18:22:17.926Z",
   "definition" : [ {
-    "key" : "ldh_pretx_level",
-    "name" : "Code",
-    "type" : "INPUT"
+    "key": "ldh_level",
+    "name": "Code",
+    "type": "INPUT"
   }, {
     "key" : "description",
     "name" : "Description",


### PR DESCRIPTION
The "ldh_pretx_level" field was renamed to "ldh_level".

Two schemas using that field.

The schema "melanoma_skin" is properly referencing "ldh_level".
The schema "plasma_cell_myeloma" is referencing the old "ldh_pretx_level". 